### PR TITLE
Adds SPARQL Update support for RDFSource PATCH

### DIFF
--- a/CONSTRAINED_BY.md
+++ b/CONSTRAINED_BY.md
@@ -52,7 +52,7 @@ Serializations supporting quads are allowed in POST and PUT requests. Graph name
 HTTP PATCH
 -----------
 
-We currently support HTTP PATCH only with the LDPatch format. PATCH requests must have a content type header specifying `text/ldpatch`. SPARQL UPDATE and/or SPARQLPatch support is planned for future development.
+We currently support HTTP PATCH with the LDPatch and SPARQL Update formats. PATCH requests must have a content type header specifying `text/ldpatch` or `application/sparql-update`. `400 Bad Request` is given if the respective engine determines that the request body is malformed.
 
 ----
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -62,8 +62,7 @@ LDP Implementation Overview
 
 ### 4.2.7 HTTP PATCH
 
- - PATCH support is implemented with the LDPatch format. Additional formats are
- planned as future development.
+ - PATCH support is implemented with the LDPatch format and with SPARQL Update.
 
 ### 4.2.8 HTTP OPTIONS
 
@@ -268,7 +267,8 @@ Handling of Non-Normative Notes
  for resources indended to be created or accessed over this server.
  - __6.2.3__ After delete, we supply `410 GONE` responses. Resourced deleted are
  treated as permanently deleted. Clients may recover them manually.
- - __6.2.5__ We are considering options for HTTP PATCH implementations.
+ - __6.2.5__ PATCH support is implemented with the LDPatch format and with SPARQL
+ Update.
  - __6.2.6__ We do not infer content types (or LDP interaction models) from
  resource contents, instead relying exclusively on the headers defined and used
  by LDP.

--- a/lib/rdf/ldp/container.rb
+++ b/lib/rdf/ldp/container.rb
@@ -116,10 +116,12 @@ module RDF::LDP
 
     def patch(status, headers, env)
       check_precondition!(env)
-      raise UnsupportedMediaType unless env['CONTENT_TYPE'] == 'text/ldpatch'
+      method = patch_types[env['CONTENT_TYPE']]
+
+      raise UnsupportedMediaType unless method
 
       temp_graph = RDF::Graph.new << graph.statements
-      ld_patch(env['rack.input'], temp_graph)
+      send(method, env['rack.input'], temp_graph)
 
       validate_triples!(temp_graph)
       graph.clear!

--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -372,9 +372,9 @@ module RDF::LDP
     end
 
     ##
-    # @return [String] the Accept-Post headers
+    # @return [String] the Accept-Patch headers
     def accept_patch
-      'text/ldpatch'
+      respond_to?(:patch_types, true) ? patch_types.keys.join(',') : ''
     end
 
     ##


### PR DESCRIPTION
SPARQL Update requests must be sent with content-type: 
`application/sparql-update`. The execution is handled by `SPARQL.execute` 
over the individual `RDFSource` graph.
