### PR TITLE
Add default prefixes to Writer

### DIFF
--- a/lib/rack/ldp.rb
+++ b/lib/rack/ldp.rb
@@ -112,8 +112,13 @@ module Rack
     # Specializes {Rack::LinkedData::ContentNegotiation}, making the default 
     # return type 'text/turtle'
     class ContentNegotiation < Rack::LinkedData::ContentNegotiation
+      DEFAULT_PREFIXES = 
+        Hash[*RDF::Vocabulary.map { |v| [v.__prefix__, v.to_uri] }.flatten]
+        .freeze
+
       def initialize(app, options = {})
         options[:default] ||= 'text/turtle'
+        options[:prefixes] ||= DEFAULT_PREFIXES
         super
       end
     end

--- a/spec/rack/ldp_spec.rb
+++ b/spec/rack/ldp_spec.rb
@@ -124,6 +124,16 @@ describe 'middleware' do
         conneg = described_class.new(app, default: ctype)
         expect(conneg.options[:default]).to eq ctype
       end
+
+      it 'sets prefixes' do
+        expect(subject.options[:prefixes]).to include({ rdf: RDF.to_uri })
+      end
+
+      it 'accepts overrides to default content type' do
+        prefix = { moomin: RDF::URI('http://ex.org/moomin') }
+        conneg = described_class.new(app, prefixes: prefix)
+        expect(conneg.options[:prefixes]).to eq prefix
+      end
     end
   end
 end


### PR DESCRIPTION
Adds default prefixes to the Writer used by `Rack::LDP::ContentNegotiation`.
