### PR TITLE
Update Last-Modified & ETag for containment

### DIFF
--- a/lib/rdf/ldp/container.rb
+++ b/lib/rdf/ldp/container.rb
@@ -91,6 +91,7 @@ module RDF::LDP
     # @return [Container] self
     def add_containment_triple(resource)
       graph << make_containment_triple(resource)
+      set_last_modified
       self
     end
 
@@ -101,6 +102,7 @@ module RDF::LDP
     # @return [Container] self
     def remove_containment_triple(resource)
       graph.delete(make_containment_triple(resource))
+      set_last_modified
       self
     end
 

--- a/lib/rdf/ldp/direct_container.rb
+++ b/lib/rdf/ldp/direct_container.rb
@@ -152,7 +152,7 @@ module RDF::LDP
       end
 
       yield(membership_resource, triple, resource) if block_given?
-
+      membership_resource.send(:set_last_modified)
       self
     end
   end

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -62,6 +62,16 @@ shared_examples 'a Container' do
       expect(subject.remove_containment_triple(resource).graph)
         .not_to include subject.make_containment_triple(resource)
     end
+
+    it 'updates last_modified for container' do
+      expect { subject.remove_containment_triple(resource) }
+        .to change { subject.last_modified }
+    end
+
+    it 'updates etag for container' do
+      expect { subject.remove_containment_triple(resource) }
+        .to change { subject.etag }
+    end
   end
 
   describe '#make_containment_triple' do
@@ -188,6 +198,16 @@ shared_examples 'a Container' do
       it 'adds containment statement to resource' do
         expect { subject.request(:POST, 200, {}, env) }
           .to change { subject.containment_triples.count }.from(0).to(1)
+      end
+
+      it 'updates last_modified for container' do
+        expect { subject.request(:POST, 200, {}, env) }
+          .to change { subject.last_modified }
+      end
+
+      it 'updates etag for container' do
+        expect { subject.request(:POST, 200, {}, env) }
+          .to change { subject.etag }
       end
 
       context 'with Container interaction model' do

--- a/spec/support/shared_examples/direct_container.rb
+++ b/spec/support/shared_examples/direct_container.rb
@@ -37,6 +37,16 @@ shared_examples 'a DirectContainer' do
           .to have_statement subject.make_membership_triple(resource_uri)
       end
 
+      it 'updates last_modified for membership resource' do
+        expect { subject.add(resource_uri).graph }
+          .to change { subject.last_modified }
+      end
+
+      it 'updates etag for for membership resource' do
+        expect { subject.add(resource_uri).graph }
+          .to change { subject.etag }
+      end
+
       it 'adds membership triple to custom membership resource' do
         repo = RDF::Repository.new
         subject = described_class.new(uri, repo)


### PR DESCRIPTION
Updates Last-Modified & ETags when adding or removing containment
and memebership triples from a resource.
