### PR TITLE
Retrieve an RDFSource's graph lazily

### DIFF
--- a/lib/rdf/ldp/rdf_source.rb
+++ b/lib/rdf/ldp/rdf_source.rb
@@ -24,10 +24,6 @@ module RDF::LDP
   #   of ldp:RDFSource in the LDP specification
   class RDFSource < Resource
 
-    # @!attribute [rw] graph
-    #   a graph representing the current persistent state of the resource.
-    attr_accessor :graph
-
     class << self
       ##
       # @return [RDF::URI] uri with lexical representation 
@@ -42,9 +38,17 @@ module RDF::LDP
     ##
     # @see RDF::LDP::Resource#initialize
     def initialize(subject_uri, data = RDF::Repository.new)
-      @graph = RDF::Graph.new(subject_uri, data: data)
+      @subject_uri = subject_uri
+      @data = data
       super
       self
+    end
+
+    ##
+    # @return [RDF::Graph] a graph representing the current persistent state of 
+    #   the resource.
+    def graph
+      @graph ||= RDF::Graph.new(@subject_uri, data: @data)
     end
 
     ##

--- a/spec/support/shared_examples/rdf_source.rb
+++ b/spec/support/shared_examples/rdf_source.rb
@@ -237,6 +237,11 @@ shared_examples 'an RDFSource' do
           .to contain_exactly(200, a_hash_including('abc' => 'def'), subject)
       end
 
+      it 'does not call the graph' do
+        expect(subject).not_to receive(:graph)
+        subject.request(:GET, 200, {'abc' => 'def'}, {})
+      end
+
       it 'returns 410 GONE when destroyed' do
         allow(subject).to receive(:destroyed?).and_return true
         expect { subject.request(:GET, 200, {'abc' => 'def'}, {}) }


### PR DESCRIPTION
This avoids instantiating the primary `RDF::Graph` for an `RDFSource` until it is needed. The graph won't be read if, e.g., the `Rack::ConditionalGet` middleware is used before the response is built.
