### PR TITLE
Handle HTTP MethodNotSupported errors consistently

### DIFF
--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -340,7 +340,7 @@ module RDF::LDP
       raise Gone if destroyed?
       begin
         send(method.to_sym.downcase, status, headers, env)
-      rescue NotImplementedError, NoMethodError => e
+      rescue NotImplementedError => e
         raise MethodNotAllowed, method 
       end
     end
@@ -375,6 +375,36 @@ module RDF::LDP
     end
 
     ##
+    # @abstract implement in subclasses as needed to support HTTP PATCH
+    def patch(*)
+      raise NotImplementedError
+    end
+
+    ##
+    # @abstract implement in subclasses as needed to support HTTP POST
+    def post(*)
+      raise NotImplementedError
+    end
+
+    ##
+    # @abstract implement in subclasses as needed to support HTTP PUT
+    def put(*)
+      raise NotImplementedError
+    end
+
+    ##
+    # @abstract HTTP TRACE is not expected to be supported
+    def trace(*)
+      raise NotImplementedError
+    end
+
+    ##
+    # @abstract HTTP CONNECT is not expected to be supported
+    def connect(*)
+      raise NotImplementedError
+    end
+
+    ##
     # @return [RDF::URI] the name for this resource's metagraph
     def metagraph_name
       subject_uri / '#meta'
@@ -403,7 +433,7 @@ module RDF::LDP
     ##
     # @return [String] the Accept-Post headers
     def accept_post
-      RDF::Reader.map { |klass| klass.format.content_type }.flatten.join(', ')
+      RDF::Reader.map(&:format).compact.map(&:content_type).flatten.join(', ')
     end
 
     ##


### PR DESCRIPTION
We were previously catching `NoMethodError` and interpreting it as
`MethodNotSupported`. This led to cases where a `NoMethodError` thrown
deep in a call stack led to the wrong HTTP response code. To fix this,
we tighten up the handling to require a `NotImplementedError` on the
method call.
