### PR TITLE
Use weak ETags

### DIFF
--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -234,7 +234,7 @@ module RDF::LDP
     #   description of strong vs. weak validators
     def etag
       return nil unless exists?
-      "\"#{subject_uri}#{last_modified.iso8601(6)}\""
+      "W/\"#{last_modified.new_offset(0).iso8601(9)}\""
     end
 
     ##


### PR DESCRIPTION
ETags are handled with Last-Modified, which makes them weak by
default. This uses weak ETags, and tightens up the usage in general.
