### PR TITLE
Use `RDF::Graph#query` for query use cases

### DIFF
--- a/lib/rdf/ldp/direct_container.rb
+++ b/lib/rdf/ldp/direct_container.rb
@@ -133,8 +133,8 @@ module RDF::LDP
     end
 
     def member_relation_statements
-      graph.statements.select do |st| 
-        st.subject == subject_uri && RELATION_TERMS.include?(st.predicate)
+      graph.query([subject_uri, nil, nil]).select do |st|
+        RELATION_TERMS.include?(st.predicate)
       end
     end
 

--- a/lib/rdf/ldp/indirect_container.rb
+++ b/lib/rdf/ldp/indirect_container.rb
@@ -60,10 +60,8 @@ module RDF::LDP
     private
 
     def inserted_content_statements
-      graph.statements.select do |st| 
-        st.subject == subject_uri && 
-          st.predicate == RDF::Vocab::LDP.insertedContentRelation
-      end
+      graph.query([subject_uri, RDF::Vocab::LDP.insertedContentRelation, nil])
+        .statements
     end
     
     def process_membership_resource(resource, &block)


### PR DESCRIPTION
In some cases, we were iterating through all the statements in a graph. In general `#query` is more semantically correct and should be faster in specific implementations, avoiding the need to touch any statement that doesn't match the pattern.

This is a minor refactor, possibly improving performance.
