### PR TITLE
Upgrade to RDF.rb 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,5 @@ rvm:
   - 2.1
   - 2.2.4
   - 2.3.0
-  - jruby
-  - rbx-2
 cache: bundler
 sudo: false
-matrix:
-  allow_failures:
-    - rvm: jruby

--- a/CONSTRAINED_BY.md
+++ b/CONSTRAINED_BY.md
@@ -31,7 +31,7 @@ Sending a PUT request to a non-existant Resource creates a Resource at that URI 
 
 ### Membership URI/Predicate
 
-The LDP specification requires the presence of _exactly one_ membership-constant-uri and membership predicate for each Direct Container. We do not impose this requirement on creation or update of a container. Attempts to POST to a Direct Container missing one of these triples will cause the defaults to be added and used for that request. Attempts to POST to a Direct Container with more than one of either of these triples will fail with `Not Allowed`. The defaults are:
+The LDP specification requires the presence of _exactly one_ membership-constant-uri and membership predicate for each Direct Container. We impose this requirement on creation by adding a default values if one is not present. Attempts to POST to a Direct Container missing one of these triples, or with more than one value for either, will fail with `Not Allowed`. The defaults are:
 
   - membership-constant-uri: the container itself as 
   - membership-predicate: `ldp:member`
@@ -40,7 +40,7 @@ We allow the user to edit the relevant triples at their own discretion (effectiv
 
 ### Inserted Content Relations
 
-Indirect Containers are required to have _exactly one_ `ldp:insertedContentRelation`. We do not impose this requirement on creation or update of an Indirect Container. Attepts to POST to an Indirect Container missing this triple will cause `ldp:MemberRelation` to be added to its RDF representation and used for that request. Attempts to POST to an Indirect Container with more than one inserted content relation will fail with `Not Allowed`.
+Indirect Containers are required to have _exactly one_ `ldp:insertedContentRelation`. We do not impose this requirement on creation by adding a default of `ldp:MemberRelation` if one is not present. This requirement is not enforced on update of an Indirect Container. Attempts to POST to an Indirect Container missing this triple or with more than one inserted content relation will fail with `Not Allowed`.
 
 For Indirect Contianers with an `ldp:insertedContentRelation` other than `ldp:MemberRelation`, attempts to POST a resource (including an LDP-NR) without the expected content relation triple will fail with `Not Allowed`. This behavior also applies to LDP-RSs with multiple content relation triples.
 

--- a/lib/rdf/ldp/non_rdf_source.rb
+++ b/lib/rdf/ldp/non_rdf_source.rb
@@ -102,7 +102,8 @@ module RDF::LDP
     # @return [StorageAdapter] the content type 
     def content_type=(content_type)
       metagraph.delete([subject_uri, FORMAT_TERM])
-      metagraph << RDF::Statement(subject_uri, RDF::DC11.format, content_type)
+      metagraph << 
+        RDF::Statement(subject_uri, RDF::Vocab::DC11.format, content_type)
     end
     
     ##

--- a/rdf-ldp.gemspec
+++ b/rdf-ldp.gemspec
@@ -29,22 +29,22 @@ Gem::Specification.new do |gem|
   gem.requirements               = []
 
   gem.add_runtime_dependency     'rack', '~> 1.6'
-  gem.add_runtime_dependency     'rdf', '~> 1.99'
-  gem.add_runtime_dependency     'rdf-turtle', '~> 1.1', '>= 1.1.8'
-  gem.add_runtime_dependency     'ld-patch', '~> 0.1'
-  gem.add_runtime_dependency     'rdf-vocab', '~> 0.8', '>= 0.8.4'
+  gem.add_runtime_dependency     'rdf', '~> 2.0.0'
+  gem.add_runtime_dependency     'rdf-turtle'
+  gem.add_runtime_dependency     'ld-patch', '~> 0.3'
+  gem.add_runtime_dependency     'rdf-vocab', '~> 2.0'
   gem.add_runtime_dependency     'rack-linkeddata', '~> 1.1'
 
-  gem.add_runtime_dependency     'json-ld', '~> 1.1'
+  gem.add_runtime_dependency     'json-ld', '~> 2.0'
 
   gem.add_runtime_dependency     'sinatra', '~> 1.4'
 
   gem.add_runtime_dependency     'link_header', '~> 0.0', '>= 0.0.8'
 
-  gem.add_development_dependency 'rdf-spec',    '~> 1.1', '>= 1.1.13'
-  gem.add_development_dependency 'rdf-rdfxml',  '~> 1.1'
-  gem.add_development_dependency 'rdf-rdfa',    '~> 1.1'
-  gem.add_development_dependency 'rdf-xsd',     '~> 1.1'
+  gem.add_development_dependency 'rdf-spec',    '~> 2.0'
+  gem.add_development_dependency 'rdf-rdfxml',  '~> 2.0'
+  gem.add_development_dependency 'rdf-rdfa',    '~> 2.0'
+  gem.add_development_dependency 'rdf-xsd',     '~> 2.0'
   gem.add_development_dependency 'rest-client', '~> 1.7'
   gem.add_development_dependency 'rspec',       '~> 3.0'
   gem.add_development_dependency 'rack-test',   '~> 0.6'

--- a/spec/app/lamprey_spec.rb
+++ b/spec/app/lamprey_spec.rb
@@ -24,7 +24,7 @@ describe 'lamprey' do
 
         before do
           graph << RDF::Statement(RDF::URI('http://example.org/moomin'), 
-                                  RDF::DC.title,
+                                  RDF::Vocab::DC.title,
                                   'mummi')
           
           graph_str = graph.dump(:ntriples)
@@ -134,7 +134,7 @@ describe 'lamprey' do
 
       before do
         graph << RDF::Statement(RDF::URI('http://example.org/moomin'), 
-                                RDF::DC.title,
+                                RDF::Vocab::DC.title,
                                 'mummi')
       end
 
@@ -208,7 +208,7 @@ describe 'lamprey' do
           get '/moomin'
           etag = last_response.header['Etag']
           graph << RDF::Statement(RDF::Node.new,
-                                  RDF::DC.title,
+                                  RDF::Vocab::DC.title,
                                   'moomin')
           put '/moomin', graph.dump(:ttl), 'CONTENT_TYPE' => 'text/turtle'
           expect(last_response.header['Etag']).not_to eq etag

--- a/spec/lib/rdf/ldp/indirect_container_spec.rb
+++ b/spec/lib/rdf/ldp/indirect_container_spec.rb
@@ -8,28 +8,29 @@ describe RDF::LDP::IndirectContainer do
 
   describe '#membership_constant_uri' do
     it 'defaults to #subject_uri' do
+      subject.create('', 'application/n-triples')
       expect(subject.membership_constant_uri).to eq subject.subject_uri
     end
   end
 
   describe '#membership_predicate' do
     it 'defaults to ldp:member' do
+      subject.create('', 'application/n-triples')
       expect(subject.membership_predicate).to eq RDF::Vocab::LDP.member
     end
   end
 
   describe '#inserted_content_relation' do
     it 'defaults to ldp:MemberSubject' do
+      subject.create('', 'application/n-triples')
       expect(subject.inserted_content_relation)
         .to eq RDF::Vocab::LDP.MemberSubject
     end
 
     it 'inserts ldp:MemberSubject statement into graph when defaulting' do
-      expect { subject.inserted_content_relation }
-        .to change { subject.graph.statements }
-             .to(contain_exactly(RDF::Statement(subject.subject_uri,
-                                        RDF::Vocab::LDP.insertedContentRelation,
-                                        RDF::Vocab::LDP.MemberSubject)))
+      subject.create('', 'application/n-triples')
+      expect(subject.inserted_content_relation)
+        .to eq RDF::Vocab::LDP.MemberSubject
     end
   end
 end

--- a/spec/lib/rdf/ldp/resource_spec.rb
+++ b/spec/lib/rdf/ldp/resource_spec.rb
@@ -12,10 +12,14 @@ describe RDF::LDP::Resource do
         .to raise_error RDF::LDP::NotFound
     end
     context 'when the resource exists' do
-      before { graph << RDF::Statement(uri, RDF::DC.title, 'snorkmaiden') }
+      before do
+        graph << RDF::Statement(uri, RDF::Vocab::DC.title, 'snorkmaiden')
+      end
 
       let(:repository) { RDF::Repository.new }
-      let(:graph) { RDF::Graph.new(uri / '#meta', data: repository) }
+      let(:graph) do
+        RDF::Graph.new(graph_name: uri / '#meta', data: repository)
+      end
 
       it 'gives an RDFSource when no class exists in interaction models' do
         expect(described_class.find(uri, repository))

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -130,6 +130,7 @@ shared_examples 'a Container' do
       context 'when PUTing containment triples' do
         it 'when creating a resource raises a Conflict error' do
           graph << statement
+          
           expect { subject.request(:PUT, 200, {'abc' => 'def'}, env) }
             .to raise_error RDF::LDP::Conflict
         end
@@ -155,7 +156,7 @@ shared_examples 'a Container' do
           graph << statement
           
           new_st = RDF::Statement(RDF::URI('http://example.org/new_moomin'), 
-                                  RDF::DC.title, 
+                                  RDF::Vocab::DC.title, 
                                   'moomin')
           graph << new_st
           expect(subject.request(:PUT, 200, {'abc' => 'def'}, env).last.graph)
@@ -289,8 +290,8 @@ shared_examples 'a Container' do
       
       context 'with graph content' do
         before do
-          graph << RDF::Statement(uri, RDF::DC.title, 'moomin')
-          graph << RDF::Statement(RDF::Node.new, RDF.type, RDF::FOAF.Person)
+          graph << RDF::Statement(uri, RDF::Vocab::DC.title, 'moomin')
+          graph << RDF::Statement(RDF::Node.new, RDF.type, RDF::Vocab::FOAF.Person)
           graph << RDF::Statement(RDF::Node.new, RDF::Vocab::DC.creator, 'tove')
         end
 
@@ -306,7 +307,8 @@ shared_examples 'a Container' do
 
         context 'with quads' do
           let(:graph) do
-            RDF::Graph.new(subject.subject_uri, data: RDF::Repository.new)
+            RDF::Graph.new(graph_name: subject.subject_uri, 
+                           data: RDF::Repository.new)
           end
 
           let(:env) do

--- a/spec/support/shared_examples/resource.rb
+++ b/spec/support/shared_examples/resource.rb
@@ -71,9 +71,9 @@ shared_examples 'a Resource' do
                                           described_class.to_uri)
     end
 
-    it 'yields a changeset' do
+    it 'yields a transaction' do
       expect { |b| subject.create(StringIO.new(''), 'application/n-triples', &b) }
-        .to yield_with_args(an_instance_of(RDF::Transaction))
+        .to yield_with_args(be_kind_of(RDF::Transaction))
     end
 
     it 'marks resource as existing' do
@@ -105,7 +105,7 @@ shared_examples 'a Resource' do
 
     it 'yields a changeset' do
       expect { |b| subject.update(StringIO.new(''), 'application/n-triples', &b) }
-        .to yield_with_args(an_instance_of(RDF::Transaction))
+        .to yield_with_args(be_kind_of(RDF::Transaction))
     end
   end
 
@@ -190,8 +190,9 @@ shared_examples 'a Resource' do
 
     [:PATCH, :POST, :PUT, :DELETE, :TRACE, :CONNECT].each do |method|
       it "responds to or errors on #{method}" do
+        g = RDF::Graph.new << [RDF::Node.new, RDF.type, 'moomin']
         env = { 'CONTENT_TYPE' => 'application/n-triples',
-                'rack.input'   => StringIO.new('input') }
+                'rack.input'   => StringIO.new(g.dump(:ntriples)) }
 
         begin
           response = subject.request(method, 200, {}, env)


### PR DESCRIPTION
Since the library uses RDF::Transactions, this upgrade won't be backwards compatible. This is an initial compatibility release.

Direct and indirect containers now add the default required triples at creation time. This avoids relying on snapshot queries, simplifies transaction scoping, and is less complicated for the client. Some `@todo` items are introduced to isolate creation of these container
types to a single transaction scope.

Closes #46.
