### PR TITLE
Clean up Rack input stream handling

### DIFF
--- a/app/lamprey.rb
+++ b/app/lamprey.rb
@@ -2,7 +2,7 @@ require 'rack/ldp'
 require 'sinatra/base'
 
 class RDF::Lamprey < Sinatra::Base
-
+  use Rack::Lint
   use Rack::LDP::ContentNegotiation
   use Rack::LDP::Errors
   use Rack::LDP::Responses

--- a/app/lamprey.rb
+++ b/app/lamprey.rb
@@ -16,7 +16,7 @@ class RDF::Lamprey < Sinatra::Base
 
   get '/*' do
     RDF::LDP::Container.new(RDF::URI(request.url), settings.repository)
-      .create('', 'text/turtle') if settings.repository.empty?    
+      .create(StringIO.new, 'text/turtle') if settings.repository.empty?    
     RDF::LDP::Resource.find(RDF::URI(request.url), settings.repository)
   end
 

--- a/lib/rdf/ldp/non_rdf_source.rb
+++ b/lib/rdf/ldp/non_rdf_source.rb
@@ -50,7 +50,10 @@ module RDF::LDP
       storage.io { |io| IO.copy_stream(input.binmode, io) }
       super
       self.content_type = c_type
-      RDFSource.new(description_uri, @data).create('', 'application/n-triples')
+
+      RDFSource.new(description_uri, @data)
+        .create(StringIO.new, 'application/n-triples')
+
       self
     end
 

--- a/lib/rdf/ldp/non_rdf_source.rb
+++ b/lib/rdf/ldp/non_rdf_source.rb
@@ -47,7 +47,7 @@ module RDF::LDP
     #
     # @see RDF::LDP::Resource#create
     def create(input, c_type)
-      storage.io { |io| IO.copy_stream(input.binmode, io) }
+      storage.io { |io| IO.copy_stream(input, io) }
       super
       self.content_type = c_type
 
@@ -60,7 +60,7 @@ module RDF::LDP
     ##
     # @see RDF::LDP::Resource#update
     def update(input, c_type)
-      storage.io { |io| IO.copy_stream(input.binmode, io) }
+      storage.io { |io| IO.copy_stream(input, io) }
       super
       self.content_type = c_type
       self
@@ -183,7 +183,7 @@ module RDF::LDP
     #
     # @example writing to a `StorageAdapter`
     #   storage = StorageAdapter.new(an_nr_source)
-    #   storage.io { |io| io.write('moomin')
+    #   storage.io { |io| io.write('moomin') }
     #
     # Beyond this interface, implementations are permitted to behave as desired.
     # They may, for instance, reject undesirable content or alter the graph (or 

--- a/lib/rdf/ldp/rdf_source.rb
+++ b/lib/rdf/ldp/rdf_source.rb
@@ -98,8 +98,7 @@ module RDF::LDP
     # @return [RDF::LDP::Resource] self
     def create(input, content_type, &block)
       super do |transaction|
-        statements = parse_graph(input, content_type)
-        transaction.insert(statements)
+        transaction.insert(parse_graph(input, content_type))
         yield transaction if block_given?
       end
     end
@@ -137,7 +136,6 @@ module RDF::LDP
         transaction.insert parse_graph(input, content_type)
         yield transaction if block_given?
       end
-      self
     end
 
     ##
@@ -193,13 +191,13 @@ module RDF::LDP
     end
    
     def ld_patch(input, graph, &block)
-      LD::Patch.parse(input).execute(graph)
+      LD::Patch.parse(input.read).execute(graph)
     rescue LD::Patch::Error => e
       raise BadRequest, e.message
     end
 
     def sparql_update(input, graph)
-      SPARQL.execute(input, graph, update: true)
+      SPARQL.execute(input.read, graph, update: true)
     rescue SPARQL::MalformedQuery => e
       raise BadRequest, e.message
     end
@@ -245,9 +243,8 @@ module RDF::LDP
       reader = RDF::Reader.for(content_type: content_type.to_s)
       raise(RDF::LDP::UnsupportedMediaType, content_type) if reader.nil?
 
-      input = input.read if input.respond_to? :read
-
       begin
+        input.rewind
         RDF::Graph.new(graph_name: subject_uri, data: RDF::Repository.new) << 
           reader.new(input, base_uri: subject_uri, validate: true)
       rescue RDF::ReaderError => e

--- a/lib/rdf/ldp/rdf_source.rb
+++ b/lib/rdf/ldp/rdf_source.rb
@@ -246,7 +246,7 @@ module RDF::LDP
       begin
         input.rewind
         RDF::Graph.new(graph_name: subject_uri, data: RDF::Repository.new) << 
-          reader.new(input, base_uri: subject_uri, validate: true)
+          reader.new(input.read, base_uri: subject_uri, validate: true)
       rescue RDF::ReaderError => e
         raise RDF::LDP::BadRequest, e.message
       end  

--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -457,7 +457,9 @@ module RDF::LDP
     ##
     # Process & generate response for DELETE requests.
     def delete(status, headers, env)
-      [204, headers, destroy]
+      destroy
+      headers.delete('Content-Type')
+      [204, headers, []]
     end
 
     ##

--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -246,10 +246,12 @@ module RDF::LDP
     #   subclasses for the appropriate response codes.
     def update(input, content_type, &block)
       return create(input, content_type, &block) unless exists?
+
       @data.transaction(mutable: true) do |transaction|
         yield transaction if block_given?
         set_last_modified(transaction)
       end
+
       self
     end
 

--- a/spec/app/lamprey_spec.rb
+++ b/spec/app/lamprey_spec.rb
@@ -6,7 +6,7 @@ require 'lamprey'
 describe 'lamprey' do
   include ::Rack::Test::Methods
   let(:app) { RDF::Lamprey }
-  
+
   describe 'base container /' do 
     describe 'GET' do
       it 'has default content type "text/turtle"' do
@@ -118,13 +118,25 @@ describe 'lamprey' do
         expect(last_response.status).to eq 415
       end
 
-      it 'returns 400 on improper document' do
+      it 'returns 400 on improper LDPatch document' do
         patch '/', '---blah---', 'CONTENT_TYPE' => 'text/ldpatch'
+        expect(last_response.status).to eq 400
+      end
+      
+      it 'returns 400 on improper SPARQL Update document' do
+        patch '/', '---blah---', 'CONTENT_TYPE' => 'application/sparql-update'
         expect(last_response.status).to eq 400
       end
 
       it 'returns 200 on valid LDPatch' do
         patch '/', '', 'CONTENT_TYPE' => 'text/ldpatch'
+        expect(last_response.status).to eq 200
+      end
+
+      it 'returns 200 on valid SPARQL Update' do
+        update = "INSERT DATA { _:blah #{RDF::Vocab::DC.title.to_base} " \
+                 "'moomin' . }"
+        patch '/', update, 'CONTENT_TYPE' => 'application/sparql-update'
         expect(last_response.status).to eq 200
       end
     end

--- a/spec/lib/rdf/ldp/direct_container_spec.rb
+++ b/spec/lib/rdf/ldp/direct_container_spec.rb
@@ -8,14 +8,14 @@ describe RDF::LDP::DirectContainer do
 
   describe '#membership_constant_uri' do
     it 'defaults to #subject_uri' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_constant_uri).to eq subject.subject_uri
     end
   end
 
   describe '#membership_predicate' do
     it 'defaults to ldp:member' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_predicate).to eq RDF::Vocab::LDP.member
     end
   end
@@ -30,7 +30,7 @@ describe RDF::LDP::DirectContainer do
     end
 
     context 'when the membership resource exists' do
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       it 'adds membership triple to membership resource' do
         expect(subject.add(resource_uri).graph)
@@ -47,8 +47,8 @@ describe RDF::LDP::DirectContainer do
                                              RDF::Vocab::LDP.membershipResource,
                                              mem_rs.subject_uri)
 
-        subject.create(g.dump(:ntriples), 'application/n-triples')
-        mem_rs.create('', 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
+        mem_rs.create(StringIO.new, 'application/n-triples')
 
         subject.add(resource_uri)
 
@@ -65,7 +65,7 @@ describe RDF::LDP::DirectContainer do
                                         RDF::Vocab::LDP.membershipResource,
                                         mem_rs)
 
-        subject.create(g.dump(:ntriples), 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
         expect(subject.add(resource_uri).graph)
           .to have_statement subject.make_membership_triple(resource_uri)
       end

--- a/spec/lib/rdf/ldp/indirect_container_spec.rb
+++ b/spec/lib/rdf/ldp/indirect_container_spec.rb
@@ -8,27 +8,27 @@ describe RDF::LDP::IndirectContainer do
 
   describe '#membership_constant_uri' do
     it 'defaults to #subject_uri' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_constant_uri).to eq subject.subject_uri
     end
   end
 
   describe '#membership_predicate' do
     it 'defaults to ldp:member' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_predicate).to eq RDF::Vocab::LDP.member
     end
   end
 
   describe '#inserted_content_relation' do
     it 'defaults to ldp:MemberSubject' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.inserted_content_relation)
         .to eq RDF::Vocab::LDP.MemberSubject
     end
 
     it 'inserts ldp:MemberSubject statement into graph when defaulting' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.inserted_content_relation)
         .to eq RDF::Vocab::LDP.MemberSubject
     end

--- a/spec/rack/ldp_spec.rb
+++ b/spec/rack/ldp_spec.rb
@@ -113,7 +113,7 @@ describe 'middleware' do
     let(:app) { double('rack application') }
 
     it { is_expected.to be_a Rack::LinkedData::ContentNegotiation }
-
+    
     describe '.new' do
       it 'sets default content-type to text/turtle' do
         expect(subject.options[:default]).to eq 'text/turtle'

--- a/spec/support/shared_examples/container.rb
+++ b/spec/support/shared_examples/container.rb
@@ -24,7 +24,7 @@ shared_examples 'a Container' do
 
   describe '#add' do
     let(:resource) { RDF::URI('http://ex.org/mymble') }
-    before { subject.create('', 'application/n-triples') }
+    before { subject.create(StringIO.new, 'application/n-triples') }
 
     it 'returns self' do
       expect(subject.add(resource)).to eq subject
@@ -118,7 +118,7 @@ shared_examples 'a Container' do
                 "Add { #{statement.subject.to_base} " \
                 "#{statement.predicate.to_base} #{statement.object.to_base} } ." 
         env = { 'CONTENT_TYPE' => 'text/ldpatch',
-                'rack.input'   => patch }
+                'rack.input'   => StringIO.new(patch) }
 
         expect { subject.request(:patch, 200, {}, env) }
           .to raise_error RDF::LDP::Conflict
@@ -136,14 +136,14 @@ shared_examples 'a Container' do
         end
 
         it 'when resource exists raises a Conflict error' do
-          subject.create('', 'application/n-triples')
+          subject.create(StringIO.new, 'application/n-triples')
           graph << statement
           expect { subject.request(:PUT, 200, {'abc' => 'def'}, env) }
             .to raise_error RDF::LDP::Conflict
         end
 
         it 'can put existing containment triple' do
-          subject.create('', 'application/n-triples')
+          subject.create(StringIO.new, 'application/n-triples')
           subject.graph << statement
           graph << statement
           expect(subject.request(:PUT, 200, {'abc' => 'def'}, env).first)
@@ -151,7 +151,7 @@ shared_examples 'a Container' do
         end
 
         it 'writes data when putting existing containment triple' do
-          subject.create('', 'application/n-triples')
+          subject.create(StringIO.new, 'application/n-triples')
           subject.graph << statement
           graph << statement
           
@@ -164,7 +164,7 @@ shared_examples 'a Container' do
         end
 
         it 'raises conflict error when without existing containment triples' do
-          subject.create('', 'application/n-triples')
+          subject.create(StringIO.new, 'application/n-triples')
           subject.graph << statement
           expect { subject.request(:PUT, 200, {'abc' => 'def'}, env) }
             .to raise_error RDF::LDP::Conflict
@@ -175,7 +175,7 @@ shared_examples 'a Container' do
     context 'when POST is implemented', 
             if: described_class.private_method_defined?(:post) do
       let(:graph) { RDF::Graph.new }
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       let(:env) do
         { 'rack.input' => StringIO.new(graph.dump(:ntriples)),

--- a/spec/support/shared_examples/direct_container.rb
+++ b/spec/support/shared_examples/direct_container.rb
@@ -30,7 +30,7 @@ shared_examples 'a DirectContainer' do
     end
 
     context 'when the membership resource exists' do
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       it 'adds membership triple to membership resource' do
         expect(subject.add(resource_uri).graph)
@@ -57,8 +57,8 @@ shared_examples 'a DirectContainer' do
                                         RDF::Vocab::LDP.membershipResource,
                                         mem_rs.subject_uri)
 
-        subject.create(g.dump(:ntriples), 'application/n-triples')
-        mem_rs.create('', 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
+        mem_rs.create(StringIO.new, 'application/n-triples')
         
         subject.add(resource_uri)
 
@@ -76,7 +76,7 @@ shared_examples 'a DirectContainer' do
                                         RDF::Vocab::LDP.membershipResource,
                                         mem_rs)
 
-        subject.create(g.dump(:ttl), 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ttl)), 'application/n-triples')
         expect(subject.add(resource_uri).graph)
           .to have_statement subject.make_membership_triple(resource_uri)
       end
@@ -92,8 +92,8 @@ shared_examples 'a DirectContainer' do
                                              RDF::Vocab::LDP.membershipResource,
                                              nr.to_uri)
 
-        container.create(g.dump(:ntriples), 'application/n-triples')
-        nr.create(StringIO.new(''), 'application/n-triples')
+        container.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
+        nr.create(StringIO.new, 'application/n-triples')
 
         container.add(resource_uri)
         expect(nr.description.graph)
@@ -126,7 +126,7 @@ shared_examples 'a DirectContainer' do
     end
 
     context 'when the membership resource exists' do
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       it 'removes membership triple to membership resource' do
         subject.graph << subject.make_membership_triple(resource_uri)
@@ -139,7 +139,7 @@ shared_examples 'a DirectContainer' do
 
   describe '#membership_constant_uri' do
     it 'when created defaults to #subject_uri' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_constant_uri).to eq subject.subject_uri
       expect(subject.graph)
         .to have_statement RDF::Statement(subject.subject_uri, 
@@ -172,7 +172,7 @@ shared_examples 'a DirectContainer' do
 
   describe '#membership_predicate' do
     it 'when created returns a uri' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.membership_predicate).to be_a RDF::URI
     end
 
@@ -201,7 +201,7 @@ shared_examples 'a DirectContainer' do
     context 'with hasMember' do
       before do
         g = RDF::Graph.new << has_member_statement
-        subject.create(g.dump(:ntriples), 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
       end
 
       it 'is constant - predicate - derived' do
@@ -215,7 +215,7 @@ shared_examples 'a DirectContainer' do
     context 'with isMemberOf' do
       before do
         g = RDF::Graph.new << is_member_of_statement
-        subject.create(g.dump(:ntriples), 'application/n-triples')
+        subject.create(StringIO.new(g.dump(:ntriples)), 'application/n-triples')
       end
 
       it 'is derived - predicate - constant' do

--- a/spec/support/shared_examples/indirect_container.rb
+++ b/spec/support/shared_examples/indirect_container.rb
@@ -2,7 +2,10 @@ shared_examples 'an IndirectContainer' do
   it_behaves_like 'a DirectContainer'  
 
   shared_context 'with a relation' do
-    before { subject.create(graph.dump(:ntriples), 'application/n-triples') }
+    before do
+      subject.create(StringIO.new(graph.dump(:ntriples)), 
+                     'application/n-triples')
+    end
 
     let(:graph) { RDF::Graph.new << inserted_content_statement }
     let(:relation_predicate) { RDF::Vocab::DC.creator }
@@ -16,7 +19,7 @@ shared_examples 'an IndirectContainer' do
   
   describe '#inserted_content_relation' do
     it 'returns a uri' do
-      subject.create('', 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.inserted_content_relation).to be_a RDF::URI
     end
 
@@ -114,7 +117,7 @@ shared_examples 'an IndirectContainer' do
           end
 
           it 'adds triple to membership resource' do
-            contained_resource.create('', 'application/n-triples')
+            contained_resource.create(StringIO.new, 'application/n-triples')
             subject.add(contained_resource)
             expect(contained_resource.graph.statements)
               .to include RDF::Statement(contained_resource.to_uri,
@@ -123,7 +126,7 @@ shared_examples 'an IndirectContainer' do
           end
 
           it 'removes triple from membership resource' do
-            contained_resource.create('', 'application/n-triples')
+            contained_resource.create(StringIO.new, 'application/n-triples')
             subject.add(contained_resource)
             subject.remove(contained_resource)
             expect(contained_resource.graph.statements)

--- a/spec/support/shared_examples/rdf_source.rb
+++ b/spec/support/shared_examples/rdf_source.rb
@@ -277,7 +277,7 @@ shared_examples 'an RDFSource' do
       end
 
       it 'returns an empty body' do
-        expect(subject.request(:DELETE, 200, {}, {}).last.to_response)
+        expect(subject.request(:DELETE, 200, {}, {}).last)
           .to be_empty
       end
 

--- a/spec/support/shared_examples/rdf_source.rb
+++ b/spec/support/shared_examples/rdf_source.rb
@@ -8,13 +8,16 @@ shared_examples 'an RDFSource' do
 
   describe '#parse_graph' do
     it 'raises UnsupportedMediaType if no reader found' do
-      expect { subject.send(:parse_graph, 'graph', 'text/fake') }
+      expect { subject.send(:parse_graph, StringIO.new('graph'), 'text/fake') }
         .to raise_error RDF::LDP::UnsupportedMediaType
     end
 
     it 'raises BadRequest if graph cannot be parsed' do
-      expect { subject.send(:parse_graph, 'graph', 'application/n-triples') }
-        .to raise_error RDF::LDP::BadRequest
+      expect do
+        subject.send(:parse_graph, 
+                     StringIO.new('graph'), 
+                     'application/n-triples')
+      end.to raise_error RDF::LDP::BadRequest
     end
 
     describe 'parsing the graph' do
@@ -35,19 +38,16 @@ shared_examples 'an RDFSource' do
       end
  
       it 'parses turtle' do
-        expect(subject.send(:parse_graph, graph.dump(:ttl), 'text/turtle'))
+        expect(subject.send(:parse_graph, 
+                            StringIO.new(graph.dump(:ttl)), 
+                            'text/turtle'))
           .to be_isomorphic_with graph
       end
 
       it 'parses ntriples' do
-        expect(subject.send(:parse_graph, graph.dump(:ntriples), 'application/n-triples'))
-          .to be_isomorphic_with graph
-      end
-
-      it 'parses rack input' do
-        rack_io = double('Rack Input Stream')
-        allow(rack_io).to receive(:read).and_return(graph.dump(:ntriples))
-        expect(subject.send(:parse_graph, rack_io, 'application/n-triples'))
+        expect(subject.send(:parse_graph, 
+                            StringIO.new(graph.dump(:ntriples)), 
+                            'application/n-triples'))
           .to be_isomorphic_with graph
       end
     end
@@ -80,35 +80,39 @@ shared_examples 'an RDFSource' do
     let(:graph) { RDF::Graph.new }
     
     it 'does not create when graph fails to parse' do
-      begin; subject.create(graph.dump(:ttl), 'text/moomin'); rescue; end
+      begin
+        subject.create(StringIO.new(graph.dump(:ttl)), 'text/moomin')
+      rescue; end
 
       expect(subject).not_to exist
     end
     
     it 'returns itself' do
-      expect(subject.create(graph.dump(:ttl), 'text/turtle')).to eq subject
+      expect(subject.create(StringIO.new(graph.dump(:ttl)), 'text/turtle'))
+        .to eq subject
     end
 
     it 'yields a transaction' do
-      expect { |b| subject.create(graph.dump(:ttl), 'text/turtle', &b) }
-        .to yield_with_args(be_kind_of(RDF::Transaction))
+      expect do |b| 
+        subject.create(StringIO.new(graph.dump(:ttl)), 'text/turtle', &b)
+      end.to yield_with_args(be_kind_of(RDF::Transaction))
     end
 
     it 'interprets NULL URI as this resource' do
       graph << RDF::Statement(RDF::URI(), RDF::Vocab::DC.title, 'moomin')
 
-      expect(subject.create(graph.dump(:ttl), 'text/turtle').graph)
+      expect(subject.create(StringIO.new(graph.dump(:ttl)), 'text/turtle').graph)
         .to have_statement RDF::Statement(subject.subject_uri, 
                                           RDF::Vocab::DC.title, 
                                           'moomin')
     end
 
-    it 'interprets Relatives URI as this based on this resource' do
+    it 'interprets Relative URIs as this based on this resource' do
       graph << RDF::Statement(subject.subject_uri, 
                               RDF::Vocab::DC.isPartOf, 
                               RDF::URI('#moomin'))
       
-      expect(subject.create(graph.dump(:ttl), 'text/turtle').graph)
+      expect(subject.create(StringIO.new(graph.dump(:ttl)), 'text/turtle').graph)
         .to have_statement RDF::Statement(subject.subject_uri,
                                           RDF::Vocab::DC.isPartOf, 
                                           subject.subject_uri / '#moomin')
@@ -125,29 +129,33 @@ shared_examples 'an RDFSource' do
     
     shared_examples 'updating rdf_sources' do
       it 'changes the response' do
-        expect { subject.update(graph.dump(:ttl), content_type) }
+        expect { subject.update(StringIO.new(graph.dump(:ttl)), content_type) }
           .to change { subject.to_response }
       end
 
       it 'changes etag' do
-        expect { subject.update(graph.dump(:ttl), content_type) }
+        expect { subject.update(StringIO.new(graph.dump(:ttl)), content_type) }
           .to change { subject.etag }
       end
 
       it 'yields a transaction' do
-        expect { |b| subject.update(graph.dump(:ttl), content_type, &b) }
-          .to yield_with_args(be_kind_of(RDF::Transaction))
+        expect do |b| 
+          subject.update(StringIO.new(graph.dump(:ttl)), content_type, &b)
+        end.to yield_with_args(be_kind_of(RDF::Transaction))
       end
 
       context 'with bad media type' do
         it 'raises UnsupportedMediaType' do
-          expect { subject.update(graph.dump(:ttl), 'text/moomin') }
+          expect { subject.update(StringIO.new(graph.dump(:ttl)), 'text/moomin') }
             .to raise_error RDF::LDP::UnsupportedMediaType
         end
 
         it 'does not update #last_modified' do
           modified = subject.last_modified 
-          begin; subject.update(graph.dump(:ttl), 'text/moomin'); rescue; end
+          begin
+            subject.update(StringIO.new(graph.dump(:ttl)), 'text/moomin')
+          rescue; end
+
           expect(subject.last_modified).to eq modified
         end
       end
@@ -156,7 +164,7 @@ shared_examples 'an RDFSource' do
     include_examples 'updating rdf_sources' 
 
     context 'when it exists' do
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       include_examples 'updating rdf_sources' 
     end
@@ -177,7 +185,7 @@ shared_examples 'an RDFSource' do
     context 'ldpatch' do
       it 'raises BadRequest when invalid document' do
         env = { 'CONTENT_TYPE' => 'text/ldpatch',
-                'rack.input'   => '---invalid---' }
+                'rack.input'   => StringIO.new('---invalid---') }
         expect { subject.request(:patch, 200, {}, env) }
           .to raise_error RDF::LDP::BadRequest
       end
@@ -188,7 +196,7 @@ shared_examples 'an RDFSource' do
                 "Add { #{statement.subject.to_base} " \
                 "#{statement.predicate.to_base} #{statement.object.to_base} } ." 
         env = { 'CONTENT_TYPE' => 'text/ldpatch',
-                'rack.input'   => patch }
+                'rack.input'   => StringIO.new(patch) }
 
         expect { subject.request(:patch, 200, {}, env) }
           .to change { subject.graph.statements.to_a }
@@ -199,7 +207,7 @@ shared_examples 'an RDFSource' do
     context 'sparql update' do
       it 'raises BadRequest when invalid document' do
         env = { 'CONTENT_TYPE' => 'application/sparql-update',
-                'rack.input'   => '---invalid---' }
+                'rack.input'   => StringIO.new('---invalid---') }
         
         expect { subject.request(:patch, 200, {}, env) }
           .to raise_error RDF::LDP::BadRequest
@@ -210,7 +218,7 @@ shared_examples 'an RDFSource' do
                  "#{RDF::Vocab::DC.title.to_base} 'moomin' . }"
 
         env = { 'CONTENT_TYPE' => 'application/sparql-update',
-                'rack.input'   => update }
+                'rack.input'   => StringIO.new(update) }
 
         expect { subject.request(:patch, 200, {}, env) }
           .to change { subject.graph.count }.from(0).to(1)
@@ -262,7 +270,7 @@ shared_examples 'an RDFSource' do
     end
 
     context 'with :DELETE' do
-      before { subject.create('', 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       it 'returns 204' do
         expect(subject.request(:DELETE, 200, {}, {}).first).to eq 204
@@ -283,7 +291,7 @@ shared_examples 'an RDFSource' do
             if: described_class.private_method_defined?(:put) do
       let(:graph) { RDF::Graph.new }
       let(:env) do
-        { 'rack.input' => graph.dump(:ntriples),
+        { 'rack.input' => StringIO.new(graph.dump(:ntriples)),
           'CONTENT_TYPE' => 'application/n-triples' }
       end
 
@@ -303,7 +311,7 @@ shared_examples 'an RDFSource' do
       end
 
       context 'when subject exists' do
-        before { subject.create('', 'application/n-triples') }
+        before { subject.create(StringIO.new, 'application/n-triples') }
         
         it 'responds 200' do
           expect(subject.request(:PUT, 200, {'abc' => 'def'}, env))

--- a/spec/support/shared_examples/resource.rb
+++ b/spec/support/shared_examples/resource.rb
@@ -21,7 +21,7 @@ shared_examples 'a Resource' do
     end
 
     context 'while existing' do
-      before { subject.create(StringIO.new(''), 'application/n-triples') }
+      before { subject.create(StringIO.new, 'application/n-triples') }
 
       subject          { described_class.new(uri, repository) }
       let(:repository) { RDF::Repository.new }
@@ -58,13 +58,13 @@ shared_examples 'a Resource' do
       after  { Timecop.return }
 
       it 'sets last_modified' do
-        subject.create(StringIO.new(''), 'text/turtle')
+        subject.create(StringIO.new, 'text/turtle')
         expect(subject.last_modified).to eq DateTime.now
       end
     end
 
     it 'adds a type triple to metagraph' do
-      subject.create(StringIO.new(''), 'application/n-triples')
+      subject.create(StringIO.new, 'application/n-triples')
       expect(subject.metagraph)
         .to have_statement RDF::Statement(subject.subject_uri,
                                           RDF.type,
@@ -72,23 +72,23 @@ shared_examples 'a Resource' do
     end
 
     it 'yields a transaction' do
-      expect { |b| subject.create(StringIO.new(''), 'application/n-triples', &b) }
+      expect { |b| subject.create(StringIO.new, 'application/n-triples', &b) }
         .to yield_with_args(be_kind_of(RDF::Transaction))
     end
 
     it 'marks resource as existing' do
-      expect { subject.create(StringIO.new(''), 'application/n-triples') }
+      expect { subject.create(StringIO.new, 'application/n-triples') }
         .to change { subject.exists? }.from(false).to(true)
     end
 
     it 'returns self' do
-      expect(subject.create(StringIO.new(''), 'application/n-triples'))
+      expect(subject.create(StringIO.new, 'application/n-triples'))
         .to eq subject
     end
 
     it 'raises Conlict when already exists' do
-      subject.create(StringIO.new(''), 'application/n-triples')
-      expect { subject.create(StringIO.new(''), 'application/n-triples') }
+      subject.create(StringIO.new, 'application/n-triples')
+      expect { subject.create(StringIO.new, 'application/n-triples') }
         .to raise_error RDF::LDP::Conflict
     end
   end
@@ -99,12 +99,12 @@ shared_examples 'a Resource' do
     end
 
     it 'returns self' do
-      expect(subject.update(StringIO.new(''), 'application/n-triples'))
+      expect(subject.update(StringIO.new, 'application/n-triples'))
         .to eq subject
     end
 
     it 'yields a changeset' do
-      expect { |b| subject.update(StringIO.new(''), 'application/n-triples', &b) }
+      expect { |b| subject.update(StringIO.new, 'application/n-triples', &b) }
         .to yield_with_args(be_kind_of(RDF::Transaction))
     end
   end
@@ -126,14 +126,14 @@ shared_examples 'a Resource' do
   end
 
   describe '#etag' do
-    before { subject.create(StringIO.new(''), 'application/n-triples') }
+    before { subject.create(StringIO.new, 'application/n-triples') }
 
     it 'has an etag' do
       expect(subject.etag).to be_a String
     end
 
     it 'updates etag on change' do
-      expect { subject.update(StringIO.new(''), 'application/n-triples') }
+      expect { subject.update(StringIO.new, 'application/n-triples') }
         .to change { subject.etag }
     end
   end
@@ -204,7 +204,7 @@ shared_examples 'a Resource' do
     end
 
     describe 'HTTP headers' do
-      before { subject.create(StringIO.new(''), 'text/turtle') }
+      before { subject.create(StringIO.new, 'text/turtle') }
       let(:headers) { subject.request(:GET, 200, {}, {})[1] }
 
       it 'has ETag' do


### PR DESCRIPTION
The parser methods used to try to handle Strings, as well as valid Rack
inputs. This led to some unnecessary complexity, giving rise to errors
like those seen in #56. This refactors to handle only IO-like Rack Input
streams.

Most of the work here is just to reorganize the tests.

There is an odd case where `RDFSource#update` feeds the IO stream before
trying to parse a graph. For now, we aggressively `#rewind` the stream
in `#parse_graph` to this problem. This might be unduely costly, and
there is probably a better fix in the long run.

---

The later commits introduce `Rack::Lint` and deal with a few issues found by running the existing tests and the W3C suite with those in place.
