### PR TITLE
Add regression test for `#delete` order

### DIFF
--- a/spec/lib/rdf/ldp/non_rdf_source_spec.rb
+++ b/spec/lib/rdf/ldp/non_rdf_source_spec.rb
@@ -39,7 +39,7 @@ describe RDF::LDP::NonRDFSource do
       let(:input)   { 'moomin' }
       let(:message) { 'fake resource error' }
 
-      it 'leaves file on disk' do
+      it 'leaves file on disk', skip_rbx: true do
         expect { subject.destroy }.to raise_error message
 
         expect(subject).not_to be_destroyed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ RSpec.configure do |config|
   config.include(RDF::Spec::Matchers)
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
+
+  c.filter_run_excluding skip_rbx: true if RUBY_VERSION.include? 'rbx'
 end
 
 def fixture_path(filename)


### PR DESCRIPTION
Tests the changes in #62. These changes aren't enforced as part of the generic `NonRDFSource` API.
