### PR TITLE
Don't force RSpec filters

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,9 +11,6 @@ RSpec.configure do |config|
   config.include(RDF::Spec::Matchers)
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.exclusion_filter = {:ruby => lambda { |version|
-    RUBY_VERSION.to_s !~ /^#{version}/
-  }}
 end
 
 def fixture_path(filename)


### PR DESCRIPTION
Allows `rspec --tag ~integration`, significantly reducing test suite time for normal runs.
