### PR TITLE
Refactor for style

### DIFF
--- a/lib/rdf/ldp.rb
+++ b/lib/rdf/ldp.rb
@@ -13,15 +13,15 @@ require 'rdf/ldp/indirect_container'
 module RDF
   ##
   # This module implements a basic domain model for Linked Data Platform (LDP).
-  # Its classes allow CRUD operations on LDP RDFSources, NonRDFSources and 
-  # Containers, while presenting an interface appropriate for consumption by 
+  # Its classes allow CRUD operations on LDP RDFSources, NonRDFSources and
+  # Containers, while presenting an interface appropriate for consumption by
   # Rack servers.
-  #   
+  #
   # @see RDF::LDP::Resource
   # @see http://www.w3.org/TR/ldp/ for the Linked Data platform specification
   module LDP
     ##
-    # Interaction models are in reverse order of preference for POST/PUT 
+    # Interaction models are in reverse order of preference for POST/PUT
     # requests; e.g. if a client sends a request with Resource, RDFSource, and
     # BasicContainer headers, the server gives a basic container.
     INTERACTION_MODELS = {
@@ -34,20 +34,20 @@ module RDF
       RDF::LDP::NonRDFSource.to_uri => RDF::LDP::NonRDFSource
     }.freeze
 
-    CONTAINER_CLASSES = { 
-      basic:    RDF::Vocab::LDP.BasicContainer,
-      direct:   RDF::LDP::DirectContainer.to_uri,
-      indirect: RDF::LDP::IndirectContainer.to_uri
-    }
+    CONTAINER_CLASSES = {
+      basic:    RDF::Vocab::LDP.BasicContainer.freeze,
+      direct:   RDF::LDP::DirectContainer.to_uri.freeze,
+      indirect: RDF::LDP::IndirectContainer.to_uri.freeze
+    }.freeze
 
-    CONSTRAINED_BY = RDF::Vocab::LDP.constrainedBy
+    CONSTRAINED_BY = RDF::Vocab::LDP.constrainedBy.freeze
 
     ##
     # A base class for HTTP request errors.
     #
     # This and its subclasses are caught and handled by Rack::LDP middleware.
     # When a `RequestError` is caught by server middleware, its `#status` can be
-    # used as a response code and `#headers` may be added to (or replace) the 
+    # used as a response code and `#headers` may be added to (or replace) the
     # existing HTTP headers.
     class RequestError < RuntimeError
       STATUS = 500
@@ -57,7 +57,7 @@ module RDF
       end
 
       def headers
-        uri = 
+        uri =
           'https://github.com/no-reply/rdf-ldp/blob/master/CONSTRAINED_BY.md'
         { 'Link' => "<#{uri}>;rel=\"#{CONSTRAINED_BY}\"" }
       end

--- a/lib/rdf/ldp/indirect_container.rb
+++ b/lib/rdf/ldp/indirect_container.rb
@@ -1,23 +1,26 @@
 module RDF::LDP
   ##
-  # An extension of `RDF::LDP::DirectContainer` implementing indirect 
-  # containment. Adds the concept of an inserted content relation to the 
+  # An extension of `RDF::LDP::DirectContainer` implementing indirect
+  # containment. Adds the concept of an inserted content relation to the
   # features of the direct container.
   #
   # Clients MUST provide exactly one `ldp:insertedContentRelation` statement in
-  # each Indirect Container. If no `#inserted_content_relation` is given by the 
+  # each Indirect Container. If no `#inserted_content_relation` is given by the
   # client, we default to `ldp:MemberSubject`. If more than one is present,
   #
-  # Attempts to POST resources without the appropriate content relation (or 
-  # with more than one) to an Indirect Container will fail with `Not 
+  # Attempts to POST resources without the appropriate content relation (or
+  # with more than one) to an Indirect Container will fail with `Not
   # Acceptable`. LDP-NR's cannot be added since indirect membership is not well
   # defined for them, per _LDP 5.5.1.2_.
   #
-  # @see http://www.w3.org/TR/ldp/#h-ldpic-indirectmbr for an explanation if 
+  # @see http://www.w3.org/TR/ldp/#h-ldpic-indirectmbr for an explanation if
   #   indirect membership and limitiations surrounding LDP-NRs.
   # @see http://www.w3.org/TR/ldp/#dfn-linked-data-platform-indirect-container
   #   definition of LDP Indirect Container
   class IndirectContainer < DirectContainer
+    INSERTED_CONTENT_REL_URI = RDF::Vocab::LDP.insertedContentRelation.freeze
+    MEMBER_SUBJECT_URI       = RDF::Vocab::LDP.MemberSubject.freeze
+
     def self.to_uri
       RDF::Vocab::LDP.IndirectContainer
     end
@@ -31,16 +34,17 @@ module RDF::LDP
     ##
     # Creates and inserts default relation triples if none are given.
     #
-    # @see DirectContainer#create for information about the behavior and 
+    # @see DirectContainer#create for information about the behavior and
     #   transactionality of this method.
-    def create(input, content_type, &block)
+    def create(input, content_type)
       super
 
       graph.transaction(mutable: true) do |tx|
-        tx.insert RDF::Statement(subject_uri, 
-                                 RDF::Vocab::LDP.insertedContentRelation, 
-                                 RDF::Vocab::LDP.MemberSubject) if
-          inserted_content_statements.empty?
+        if inserted_content_statements.empty?
+          tx.insert RDF::Statement(subject_uri,
+                                   INSERTED_CONTENT_REL_URI,
+                                   MEMBER_SUBJECT_URI)
+        end
       end
 
       self
@@ -48,13 +52,13 @@ module RDF::LDP
 
     ##
     # Gives the inserted content relation for the indirect container. If none is
-    # present in the container state, we add `ldp:MemberSubject`, effectively 
+    # present in the container state, we add `ldp:MemberSubject`, effectively
     # treating this LDP-IC as an LDP-DC.
     #
     # @return [RDF::URI] the inserted content relation; either a predicate term
     #   or `ldp:MemberSubject`
     #
-    # @raise [RDF::LDP::NotAcceptable] if multiple inserted content relations 
+    # @raise [RDF::LDP::NotAcceptable] if multiple inserted content relations
     #   exist.
     #
     # @see http://www.w3.org/TR/ldp/#dfn-membership-triples
@@ -62,36 +66,36 @@ module RDF::LDP
       statements = inserted_content_statements
       return statements.first.object if statements.count == 1
 
-      raise NotAcceptable.new('An LDP-IC MUST have exactly ' \
-                              'one inserted content relation triple; found ' \
-                              "#{statements.count}.")
+      raise(NotAcceptable, 'An LDP-IC MUST have exactly ' \
+                           'one inserted content relation triple; found ' \
+                           "#{statements.count}.")
     end
 
     private
 
     def inserted_content_statements
-      graph.query([subject_uri, RDF::Vocab::LDP.insertedContentRelation, nil])
-        .statements
+      graph.query([subject_uri, INSERTED_CONTENT_REL_URI, nil])
+           .statements
     end
-    
-    def process_membership_resource(resource, &block)
+
+    def process_membership_resource(resource)
       resource = member_derived_uri(resource)
-      super(resource, &block)
+      super
     end
-    
+
     def member_derived_uri(resource)
       predicate = inserted_content_relation
-      return resource.to_uri if predicate == RDF::Vocab::LDP.MemberSubject
+      return resource.to_uri if predicate == MEMBER_SUBJECT_URI
 
-      raise NotAcceptable.new("#{resource.to_uri} is an LDP-NR; cannot add " \
-                              'it to an IndirectContainer with a content ' \
-                              'relation.') if resource.non_rdf_source?
+      raise(NotAcceptable, "#{resource.to_uri} is an LDP-NR; cannot add " \
+                           'it to an IndirectContainer with a content '   \
+                           'relation.') if resource.non_rdf_source?
 
       statements = resource.graph.query([resource.subject_uri, predicate, :o])
       return statements.first.object if statements.count == 1
 
-      raise NotAcceptable.new("#{statements.count} inserted content" \
-                              "#{predicate} found on #{resource.to_uri}")
+      raise(NotAcceptable, "#{statements.count} inserted content" \
+                           "#{predicate} found on #{resource.to_uri}")
     end
   end
 end

--- a/lib/rdf/ldp/non_rdf_source.rb
+++ b/lib/rdf/ldp/non_rdf_source.rb
@@ -17,8 +17,7 @@ module RDF::LDP
   #   a definition of NonRDFSource in LDP
   class NonRDFSource < Resource
     # Use DC elements format
-    FORMAT_TERM = RDF::Vocab::DC11.format
-    DESCRIBED_BY_TERM = RDF::URI('http://www.w3.org/2007/05/powder-s#describedby')
+    FORMAT_TERM = RDF::Vocab::DC11.format.freeze
 
     ##
     # @return [RDF::URI] uri with lexical representation
@@ -52,7 +51,7 @@ module RDF::LDP
       self.content_type = c_type
 
       RDFSource.new(description_uri, @data)
-        .create(StringIO.new, 'application/n-triples')
+               .create(StringIO.new, 'application/n-triples')
 
       self
     end
@@ -106,7 +105,7 @@ module RDF::LDP
     def content_type=(content_type)
       metagraph.delete([subject_uri, FORMAT_TERM])
       metagraph <<
-        RDF::Statement(subject_uri, RDF::Vocab::DC11.format, content_type)
+        RDF::Statement(subject_uri, FORMAT_TERM, content_type)
     end
 
     ##
@@ -129,9 +128,9 @@ module RDF::LDP
 
     ##
     # Process & generate response for PUT requsets.
-    def put(status, headers, env)
-      raise PreconditionFailed.new('Etag invalid') if
-        env.has_key?('HTTP_IF_MATCH') && !match?(env['HTTP_IF_MATCH'])
+    def put(_status, headers, env)
+      raise(PreconditionFailed, 'Etag invalid') if
+        env.key?('HTTP_IF_MATCH') && !match?(env['HTTP_IF_MATCH'])
 
       if exists?
         update(env['rack.input'], env['CONTENT_TYPE'])
@@ -217,8 +216,8 @@ module RDF::LDP
       #
       # @return [IO] an object conforming to the Ruby IO interface
       def io(&block)
-        FileUtils.mkdir_p(path_dir) unless Dir.exists?(path_dir)
-        FileUtils.touch(path) unless file_exists?
+        FileUtils.mkdir_p(path_dir) unless Dir.exist?(path_dir)
+        FileUtils.touch(path)       unless file_exists?
 
         File.open(path, 'r+b', &block)
       end
@@ -226,7 +225,7 @@ module RDF::LDP
       ##
       # @return [Boolean] 1 if the file has been deleted, otherwise false
       def delete
-        return false unless File.exists?(path)
+        return false unless file_exists?
         File.delete(path)
       end
 
@@ -235,7 +234,7 @@ module RDF::LDP
       ##
       # @return [Boolean]
       def file_exists?
-        File.exists?(path)
+        File.exist?(path)
       end
 
       ##

--- a/lib/rdf/ldp/resource.rb
+++ b/lib/rdf/ldp/resource.rb
@@ -56,8 +56,8 @@ module RDF::LDP
   #   resource.exists? # => true
   #   resource.destroyed? # => true
   #
-  # Rack (via `RDF::LDP::Rack`) uses the `#request` method to dispatch requests and
-  # interpret responses. Disallowed HTTP methods result in
+  # Rack (via `RDF::LDP::Rack`) uses the `#request` method to dispatch requests
+  # and interpret responses. Disallowed HTTP methods result in
   # `RDF::LDP::MethodNotAllowed`. Individual Resources populate `Link`, `Allow`,
   # `ETag`, `Last-Modified`, and `Accept-*` headers as required by LDP. All
   # subclasses (MUST) return `self` as the Body, and respond to `#each`/
@@ -84,6 +84,10 @@ module RDF::LDP
   # @see http://www.w3.org/TR/ldp/#dfn-linked-data-platform-resource for a
   #   definition of 'Resource' in LDP
   class Resource
+    CONTAINS_URI       = RDF::Vocab::LDP.contains.freeze
+    INVALIDATED_AT_URI = RDF::Vocab::PROV.invalidatedAtTime.freeze
+    MODIFIED_URI       = RDF::Vocab::DC.modified.freeze
+
     # @!attribute [r] subject_uri
     #   an rdf term identifying the `Resource`
     attr_reader :subject_uri
@@ -149,18 +153,19 @@ module RDF::LDP
       # @return [Class] a subclass of {RDF::LDP::Resource} matching the
       #   requested interaction model;
       def interaction_model(link_header)
-        models = LinkHeader.parse(link_header)
-                 .links.select { |link| link['rel'].downcase == 'type' }
-                 .map { |link| link.href }
+        models =
+          LinkHeader.parse(link_header)
+                    .links.select { |link| link['rel'].casecmp 'type' }
+                    .map { |link| link.href }
 
         return RDFSource if models.empty?
         match = INTERACTION_MODELS.keys.reverse.find { |u| models.include? u }
 
         if match == RDF::LDP::NonRDFSource.to_uri
           raise NotAcceptable if
-            models.include?(RDF::LDP::RDFSource.to_uri) ||
-            models.include?(RDF::LDP::Container.to_uri) ||
-            models.include?(RDF::LDP::DirectContainer.to_uri) ||
+            models.include?(RDF::LDP::RDFSource.to_uri)         ||
+            models.include?(RDF::LDP::Container.to_uri)         ||
+            models.include?(RDF::LDP::DirectContainer.to_uri)   ||
             models.include?(RDF::LDP::IndirectContainer.to_uri) ||
             models.include?(RDF::URI('http://www.w3.org/ns/ldp#BasicContainer'))
         end
@@ -217,7 +222,7 @@ module RDF::LDP
     # @raise [RDF::LDP::RequestError] when creation fails. May raise various
     #   subclasses for the appropriate response codes.
     # @raise [RDF::LDP::Conflict] when the resource exists
-    def create(input, content_type, &block)
+    def create(_input, _content_type)
       raise Conflict if exists?
 
       @data.transaction(mutable: true) do |transaction|
@@ -268,13 +273,13 @@ module RDF::LDP
     #
     # @todo Use of owl:Nothing is probably problematic. Define an internal
     # namespace and class represeting deletion status as a stateful property.
-    def destroy(&block)
+    def destroy
       @data.transaction(mutable: true) do |transaction|
         containers.each { |c| c.remove(self, transaction) if c.container? }
         transaction.insert RDF::Statement(subject_uri,
-                                      RDF::Vocab::PROV.invalidatedAtTime,
-                                      DateTime.now,
-                                      graph_name: metagraph_name)
+                                          INVALIDATED_AT_URI,
+                                          DateTime.now,
+                                          graph_name: metagraph_name)
         yield transaction if block_given?
       end
       self
@@ -294,8 +299,8 @@ module RDF::LDP
     ##
     # @return [Boolean] true if resource has been destroyed
     def destroyed?
-      times = @metagraph.query([subject_uri, RDF::Vocab::PROV.invalidatedAtTime, nil])
-      !(times.empty?)
+      times = @metagraph.query([subject_uri, INVALIDATED_AT_URI, nil])
+      !times.empty?
     end
 
     ##
@@ -382,7 +387,7 @@ module RDF::LDP
     ##
     # @return [Array<RDF::LDP::Resource>] the container for this resource
     def containers
-      @data.query([:s, RDF::Vocab::LDP.contains, subject_uri]).map do |st|
+      @data.query([:s, CONTAINS_URI, subject_uri]).map do |st|
         RDF::LDP::Resource.find(st.subject, @data)
       end
     end
@@ -396,7 +401,7 @@ module RDF::LDP
     def to_response
       []
     end
-    alias_method :each, :to_response
+    alias each to_response
 
     ##
     # Build the response for the HTTP `method` given.
@@ -426,7 +431,7 @@ module RDF::LDP
       raise Gone if destroyed?
       begin
         send(method.to_sym.downcase, status, headers, env)
-      rescue NotImplementedError => e
+      rescue NotImplementedError
         raise MethodNotAllowed, method
       end
     end
@@ -436,27 +441,27 @@ module RDF::LDP
     ##
     # Generate response for GET requests. Returns existing status and headers,
     # with `self` as the body.
-    def get(status, headers, env)
+    def get(status, headers, _env)
       [status, update_headers(headers), self]
     end
 
     ##
     # Generate response for HEAD requsets. Adds appropriate headers and returns
     # an empty body.
-    def head(status, headers, env)
+    def head(status, headers, _env)
       [status, update_headers(headers), []]
     end
 
     ##
     # Generate response for OPTIONS requsets. Adds appropriate headers and
     # returns an empty body.
-    def options(status, headers, env)
+    def options(status, headers, _env)
       [status, update_headers(headers), []]
     end
 
     ##
     # Process & generate response for DELETE requests.
-    def delete(status, headers, env)
+    def delete(_status, headers, _env)
       destroy
       headers.delete('Content-Type')
       [204, headers, []]
@@ -503,7 +508,7 @@ module RDF::LDP
     # @return [Hash<String, String>] the updated headers
     def update_headers(headers)
       headers['Link'] =
-        ([headers['Link']] + link_headers).compact.join(",")
+        ([headers['Link']] + link_headers).compact.join(',')
 
       headers['Allow'] = allowed_methods.join(', ')
       headers['Accept-Post'] = accept_post   if respond_to?(:post, true)
@@ -561,18 +566,15 @@ module RDF::LDP
         # transactions do not support updates or pattern deletes, so we must
         # ask the Repository for the current last_modified to delete the statement
         # transactionally
-        modified = last_modified
-        transaction.delete RDF::Statement(subject_uri,
-                                          RDF::Vocab::DC.modified,
-                                          modified,
-                                          graph_name: metagraph_name) if modified
+        transaction
+          .delete RDF::Statement(subject_uri, MODIFIED_URI, last_modified,
+                                 graph_name: metagraph_name) if last_modified
 
-        transaction.insert RDF::Statement(subject_uri,
-                                          RDF::Vocab::DC.modified,
-                                          DateTime.now,
-                                          graph_name: metagraph_name)
+        transaction
+          .insert RDF::Statement(subject_uri, MODIFIED_URI, DateTime.now,
+                                 graph_name: metagraph_name)
       else
-        metagraph.update([subject_uri, RDF::Vocab::DC.modified, DateTime.now])
+        metagraph.update([subject_uri, MODIFIED_URI, DateTime.now])
       end
     end
 


### PR DESCRIPTION
Freeze constants, constantize frequently used `RDF::Vocab` terms, & cleanup style for rubocop.
