### PR TITLE
Drop support for Ruby < 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ script: "bundle exec rspec spec"
 env:
   - CI=true
 rvm:
-  - 2.0
-  - 2.1
   - 2.2.4
   - 2.3.1
   - jruby-9.0.4.0

--- a/rdf-ldp.gemspec
+++ b/rdf-ldp.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.require_paths      = %w(lib app)
   gem.has_rdoc           = false
 
-  gem.required_ruby_version      = '>= 2.0.0'
+  gem.required_ruby_version      = '>= 2.2.2'
   gem.requirements               = []
 
   gem.add_runtime_dependency     'rack', '~> 1.6'


### PR DESCRIPTION
This is now standard across the RDF.rb suite.
