### PR TITLE
Simplify member triples handling; add support for arbitrary members

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -225,9 +225,8 @@ ignore `ldp:insertedContentRelation` on DirectContainers.
 - __5.4.2.1__: Triples are created as described when POSTing to a container. We
 allow clients to delete and replace triples at their own risk, per the MAY in
 this section.
-  - Membership triples are added to the Membership Resource's graph unless
-  the Membership Resource does not exist on the server. In this case, they are
-  added to the member's graph.
+  - Membership triples are added to the containers graph for both the
+  `ldp:hasMemberRelation` and `isMemberOfRelation` cases.
   - If the Membership Resource is an LDP-NR, membership triples are added to
   the server-created LDP-RS (`describedby`, resource).
   - POST requests are rejected if the Membership Resource does not exist.

--- a/lib/rdf/ldp/indirect_container.rb
+++ b/lib/rdf/ldp/indirect_container.rb
@@ -78,12 +78,12 @@ module RDF::LDP
            .statements
     end
 
-    def process_membership_resource(resource)
-      resource = member_derived_uri(resource)
-      super
+    def process_membership_resource(resource, transaction = nil)
+      member = member_derived_uri(resource, transaction)
+      super(resource, transaction, member)
     end
 
-    def member_derived_uri(resource)
+    def member_derived_uri(resource, transaction = nil)
       predicate = inserted_content_relation
       return resource.to_uri if predicate == MEMBER_SUBJECT_URI
 
@@ -91,7 +91,8 @@ module RDF::LDP
                            'it to an IndirectContainer with a content '   \
                            'relation.') if resource.non_rdf_source?
 
-      statements = resource.graph.query([resource.subject_uri, predicate, :o])
+      target = transaction || resource.graph
+      statements = target.query([resource.subject_uri, predicate, :o])
       return statements.first.object if statements.count == 1
 
       raise(NotAcceptable, "#{statements.count} inserted content" \

--- a/spec/lib/rdf/ldp/direct_container_spec.rb
+++ b/spec/lib/rdf/ldp/direct_container_spec.rb
@@ -52,7 +52,7 @@ describe RDF::LDP::DirectContainer do
 
         subject.add(resource_uri)
 
-        expect(mem_rs.graph)
+        expect(subject.graph)
           .to have_statement subject.make_membership_triple(resource_uri)
       end
 


### PR DESCRIPTION
Membership triples are now added to the container for all cases. This
simplifies behavior where the location of the membership triples
depended on whether the membership constant URI was a server resource.

Support for members that are not stored by the server is added; e.g.:

```
# indirect container
<> ldp:isMemberOfRelation skos:inScheme ;
   ldp:membershipResource <http://ex.com/myScheme> ;
   ldp:insertedContentRelation foaf:primaryTopic .

# member of indirect container
<> foaf:primaryTopic <http://ex.com/concept> .
```

The above now succeeds, adding the following triple to the container:

```
<http://ex.com/concept> skos:inScheme <http://ex.com/myScheme> .
```
