### PR TITLE
Fix 'describedby' headers for NonRDFSource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ rvm:
   - rbx
 cache: bundler
 sudo: false
+matrix:
+  allow_failures:
+    - rvm: rbx

--- a/lib/rdf/ldp/non_rdf_source.rb
+++ b/lib/rdf/ldp/non_rdf_source.rb
@@ -161,7 +161,7 @@ module RDF::LDP
     end
 
     def link_headers
-      super << "<#{description_uri}>;rel=\"describedBy\""
+      super << "<#{description_uri}>;rel=\"describedby\""
     end
   end
 end


### PR DESCRIPTION
`"describedBy"` was erroneously camel cased.
