### PR TITLE
Make interaction models pluggable

### DIFF
--- a/lib/rdf/ldp.rb
+++ b/lib/rdf/ldp.rb
@@ -9,6 +9,7 @@ require 'rdf/ldp/non_rdf_source'
 require 'rdf/ldp/container'
 require 'rdf/ldp/direct_container'
 require 'rdf/ldp/indirect_container'
+require 'rdf/ldp/interaction_model'
 
 module RDF
   ##
@@ -20,20 +21,12 @@ module RDF
   # @see RDF::LDP::Resource
   # @see http://www.w3.org/TR/ldp/ for the Linked Data platform specification
   module LDP
-    ##
-    # Interaction models are in reverse order of preference for POST/PUT
-    # requests; e.g. if a client sends a request with Resource, RDFSource, and
-    # BasicContainer headers, the server gives a basic container.
-    INTERACTION_MODELS = {
-      RDF::Vocab::LDP.Resource => RDF::LDP::RDFSource,
-      RDF::LDP::RDFSource.to_uri => RDF::LDP::RDFSource,
-      RDF::LDP::Container.to_uri => RDF::LDP::Container,
-      RDF::Vocab::LDP.BasicContainer => RDF::LDP::Container,
-      RDF::LDP::DirectContainer.to_uri => RDF::LDP::DirectContainer,
-      RDF::LDP::IndirectContainer.to_uri => RDF::LDP::IndirectContainer,
-      RDF::LDP::NonRDFSource.to_uri => RDF::LDP::NonRDFSource
-    }.freeze
-
+    InteractionModel.register(RDF::LDP::RDFSource, default: true)
+    InteractionModel.register(RDF::LDP::Container, for: RDF::Vocab::LDP.BasicContainer)
+    InteractionModel.register(RDF::LDP::DirectContainer)
+    InteractionModel.register(RDF::LDP::IndirectContainer)
+    InteractionModel.register(RDF::LDP::NonRDFSource)
+    
     CONTAINER_CLASSES = {
       basic:    RDF::Vocab::LDP.BasicContainer.freeze,
       direct:   RDF::LDP::DirectContainer.to_uri.freeze,

--- a/lib/rdf/ldp/interaction_model.rb
+++ b/lib/rdf/ldp/interaction_model.rb
@@ -1,0 +1,87 @@
+module RDF
+  module LDP
+    class InteractionModel
+      class << self
+        ##
+        # Interaction models are in reverse order of preference for POST/PUT
+        # requests; e.g. if a client sends a request with Resource, RDFSource, and
+        # BasicContainer headers, the server gives a basic container.
+        #
+        # Interaction models are initialized in the correct order, but with no classed
+        # registered to handle them.
+        @@interaction_models = {
+          RDF::LDP::RDFSource.to_uri         => nil,
+          RDF::LDP::Container.to_uri         => nil,
+          RDF::Vocab::LDP.BasicContainer     => nil,
+          RDF::LDP::DirectContainer.to_uri   => nil,
+          RDF::LDP::IndirectContainer.to_uri => nil,
+          RDF::LDP::NonRDFSource.to_uri      => nil
+        }
+        
+        ##
+        # Register a new interaction model for one or more Link header URIs. klass.to_uri
+        # will automatically be registered.
+        #
+        # @param [RDF::LDP::Resource] klass  the implementation class to register
+        # @param [Hash <Symbol, *>] opts   registration options:
+        #   :default [true, false]  if true, klass will become the new default klass for
+        #     unrecognized Link headers
+        #   :for [RDF::URI, Array<RDF::URI>]  additional URIs for which klass should become 
+        #     the interaction model
+        #
+        # @return [RDF::LDP::Resource] klass
+        def register(klass, opts={})
+          unless klass.ancestors.include?(RDF::LDP::Resource)
+            raise ArgumentError, "Interaction models must subclass `RDF::LDP::Resource`" 
+          end
+          @@default = klass if opts[:default] or @@default.nil?
+          @@interaction_models[klass.to_uri] = klass
+          Array(opts[:for]).each do |model|
+            @@interaction_models[model] = klass
+          end
+          klass
+        end
+        
+        ##
+        # Find the appropriate interaction model given a set of Link header URIs.
+        #
+        # @param [Array<RDF::URI>] uris
+        #
+        # @return [Class] a subclass of {RDF::LDP::Resource} that most narrowly matches the
+        #   supplied `uris`, or the default interaction model if nothing matches
+        def find(uris)
+          match = @@interaction_models.keys.reverse.find { |u| uris.include? u } 
+          self.for(match) || @@default
+        end
+        
+        ##
+        # Find the interaction model registered for a given uri
+        #
+        # @param [RDF::URI] uri
+        #
+        # @return [Class] the {RDF::LDP::Resource} subclass registered to `uri`
+        def for(uri)
+          @@interaction_models[uri]
+        end
+        
+        ##
+        # The default registered interaction model
+        def default
+          @@default
+        end
+        
+        ##
+        # Test an array of URIs to see if their interaction models are compatible (e.g., all of the URIs
+        # refer either to RDF models or non-RDF models, but not a combination of both).
+        #
+        # @param [Array<RDF::URI>] uris
+        # @return [TrueClass or FalseClass]  true if the models specified by `uris` are compatible
+        def compatible?(uris)
+          classes = uris.collect { |m| self.for(m) }
+          (rdf,non_rdf) = classes.compact.partition { |c| c.ancestors.include?(RDFSource) }
+          rdf.empty? or non_rdf.empty?
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/rdf/ldp/resource_spec.rb
+++ b/spec/lib/rdf/ldp/resource_spec.rb
@@ -85,6 +85,25 @@ describe RDF::LDP::Resource do
       expect { described_class.interaction_model(header) }
         .to raise_error RDF::LDP::NotAcceptable
     end
+    
+    context 'custom implementation class' do
+      let!(:custom_container) { Class.new(RDF::LDP::Container) }
+
+      before do
+        @original_class = RDF::LDP::InteractionModel.for(RDF::Vocab::LDP.BasicContainer)
+      end
+      
+      after do
+        RDF::LDP::InteractionModel.register(@original_class, for: RDF::Vocab::LDP.BasicContainer)
+      end
+      
+      it 'matches header to class' do
+        RDF::LDP::InteractionModel.register(custom_container, for: RDF::Vocab::LDP.BasicContainer)
+        header = '<http://www.w3.org/ns/ldp#BasicContainer>;rel="type"'
+        expect(described_class.interaction_model(header))
+          .to eq custom_container
+      end
+    end
   end
 
   describe '#container?' do


### PR DESCRIPTION
This PR opens up the interaction model pattern to having alternate `RDF::LDP::Resource` descendants do the work of instantiating and populating resources.
