### PR TITLE
Move shared examples to `rdf/ldp/spec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,40 @@ And run your server with:
 $ rackup
 ```
 
+Testing
+-------
+
+RSpec shared examples for the required behaviors of LDP resource and container
+types are included in `rdf/ldp/spec` for use in customized implementations.
+Running these example sets will help ensure LDP compliance for specialized
+resource behaviors.
+
+This test suite is provided provisionally and may be incomplete or overly
+strict. Please [report issues](https://github.com/ruby-rdf/rdf-ldp/issues)
+encountered during its use.
+
+```ruby
+require 'rdf/ldp/spec'
+
+describe MyResource do
+  it_behaves_like 'a Resource'
+end
+
+describe MyRDFSource do
+  it_behaves_like 'an RDFSource'
+end
+
+# ...
+
+describe MyIndirectContainer do
+  it_behaves_like 'an IndirectContainer'
+end
+```
+
+We recommend running the official
+[LDP testsuite](https://github.com/cbeer/ldp_testsuite_wrapper), as integration
+tests in addition to the above examples.
+
 Compliance
 ----------
 

--- a/lib/rdf/ldp/spec.rb
+++ b/lib/rdf/ldp/spec.rb
@@ -1,0 +1,6 @@
+require 'rdf/ldp/spec/resource'
+require 'rdf/ldp/spec/rdf_source'
+require 'rdf/ldp/spec/non_rdf_source'
+require 'rdf/ldp/spec/container'
+require 'rdf/ldp/spec/direct_container'
+require 'rdf/ldp/spec/indirect_container'

--- a/lib/rdf/ldp/spec/container.rb
+++ b/lib/rdf/ldp/spec/container.rb
@@ -1,3 +1,5 @@
+require 'rdf/ldp/spec/rdf_source'
+
 shared_examples 'a Container' do
   it_behaves_like 'an RDFSource'
 

--- a/lib/rdf/ldp/spec/direct_container.rb
+++ b/lib/rdf/ldp/spec/direct_container.rb
@@ -1,3 +1,5 @@
+require 'rdf/ldp/spec/container'
+
 # @todo: make this set of examples less opinionated about #add behavior.
 #   Break #add tests into another group shared between DirectContainer & 
 #   IndirectContainer. This way other implementations can use these specs

--- a/lib/rdf/ldp/spec/indirect_container.rb
+++ b/lib/rdf/ldp/spec/indirect_container.rb
@@ -1,3 +1,5 @@
+require 'rdf/ldp/spec/direct_container'
+
 shared_examples 'an IndirectContainer' do
   it_behaves_like 'a DirectContainer'  
 

--- a/lib/rdf/ldp/spec/non_rdf_source.rb
+++ b/lib/rdf/ldp/spec/non_rdf_source.rb
@@ -1,3 +1,5 @@
+require 'rdf/ldp/spec/resource'
+
 shared_examples 'a NonRDFSource' do
   it_behaves_like 'a Resource'
 

--- a/lib/rdf/ldp/spec/rdf_source.rb
+++ b/lib/rdf/ldp/spec/rdf_source.rb
@@ -1,3 +1,5 @@
+require 'rdf/ldp/spec/resource'
+
 shared_examples 'an RDFSource' do
   it_behaves_like 'a Resource'
   

--- a/lib/rdf/ldp/spec/resource.rb
+++ b/lib/rdf/ldp/spec/resource.rb
@@ -1,3 +1,6 @@
+require 'rspec'
+require 'rdf/spec'
+require 'rdf/spec/matchers'
 require 'timecop'
 
 shared_examples 'a Resource' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'rdf/ldp'
 require 'rdf/spec'
 require 'rdf/spec/matchers'
 
+require 'rdf/ldp/spec'
+
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
Allow reuse of shared examples in downstream codebases.